### PR TITLE
changed L.marker to use an L.icon referencing custom .png file

### DIFF
--- a/client/scripts/src/view/map.js
+++ b/client/scripts/src/view/map.js
@@ -54,7 +54,8 @@ define(["backbone", "config", "leaflet", "ref-location"],
             if (!loc)
                 return;
 
-            var marker = L.marker(loc);
+            var normalIcon = L.icon({iconUrl: "images/marker-normal.png"})
+            var marker = L.marker(loc, {icon: normalIcon});
 
             marker.addTo(this.zoningLayer);
 
@@ -73,6 +74,7 @@ define(["backbone", "config", "leaflet", "ref-location"],
         },
 
         permitChanged: function(permit) {
+            console.log("changed")
             styleMarker(this.getMarkerForPermit(permit), permit);
         },
 


### PR DESCRIPTION
Custom permit .png images now being used as markers.  Turns out the images need to be about a quarter of the size they currently are.
