### PR TITLE
#radius-filter thumb color match map circle

### DIFF
--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -8234,6 +8234,19 @@ button.picker__today:focus, button.picker__clear:focus, button.picker__close:foc
     opacity: 0.5;
 }
 
+/* style #radius-filter range slider thumb color to match radius outline on map
+   from http://brennaobrien.com/blog/2014/05/style-input-type-range-in-every-browser.html */
+   
+#radius-filter::-webkit-slider-thumb {
+    background-color: #FF5A5A;
+}
+#radius-filter::-moz-range-thumb {
+    background-color: #FF5A5A;
+}
+#radius-filter::-ms-thumb {
+    background-color: #FF5A5A;
+}
+
 /* Permit Table */
 #permit-list {
     margin: 0;


### PR DESCRIPTION
Added CSS to get color of the Radius (feet) slider to match the color
of the circle shown on the map.

(Didn’t modify the .inactive styling or the left tail of the range.)
